### PR TITLE
Replace <<-EOS.undent with <<~EOS

### DIFF
--- a/craft-cli.rb
+++ b/craft-cli.rb
@@ -18,7 +18,7 @@ class CraftCli < Formula
     system 'craft --version'
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Verify your installation by running:
       "craft --version".
 


### PR DESCRIPTION
Fixes the following error:
Error: Calling <<-EOS.undent is disabled!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/rsanchez/homebrew-craft-cli/craft-cli.rb:27:in `caveats'